### PR TITLE
Fix typo in PHP code

### DIFF
--- a/saml/lib/Saml.php
+++ b/saml/lib/Saml.php
@@ -188,7 +188,7 @@ class Saml
 
                 // Update
                 if (count($groupsToRemove) != 0 || count($groupsToAdd) != 0) {
-                    foreach($groupToRemove as $grpId) {
+                    foreach($groupsToRemove as $grpId) {
                         \jAcl2DbUserGroup::removeUserFromGroup($login, $grpId);
                     }
 


### PR DESCRIPTION
Follow up from #17 and 4c5e734be976af894d4d38b9585049a8e3462f03

