### PR TITLE
[Feature] Use only NameID assertion to authenticate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
             }
         },
         "branch-alias": {
-            "dev-master": "2.0.x-dev",
+            "dev-master": "2.1.x-dev",
+            "dev-2.0.x": "2.0.x-dev",
             "dev-1.0.x": "1.0.x-dev"
         }
     }

--- a/saml/install/config.ini
+++ b/saml/install/config.ini
@@ -3,6 +3,7 @@
 [saml]
 automaticAccountCreation = on
 allowSAMLAccountToUseLocalPassword = on
+useOnlyNameIDAssertionToAuthenticate = off
 
 [saml:sp]
 

--- a/saml/lib/Configuration.php
+++ b/saml/lib/Configuration.php
@@ -40,6 +40,12 @@ class Configuration {
     protected $allowSAMLAccountToUseLocalPassword = true;
 
     /**
+     * @var bool says if the user should be created/authenticated using only the loginAttribute property.
+     *                attributesMapping (Login and E-Mail) will be both overwritten by the loginAttribute value
+     */
+    protected $useOnlyNameIDAssertionToAuthenticate = false;
+
+    /**
      * @var array list of dao properties that can be used for mapping
      */
     protected $daoPropertiesForMapping = array();
@@ -48,6 +54,12 @@ class Configuration {
 
 
     protected $idpLabel = '';
+
+    /**
+     * @var string placeholder used to fill login field and mandatory attributes fields if the 
+     *                  useOnlyNameIDAssertionToAuthenticate property is set to true
+     */
+    protected $nameIdPlaceholder = 'NameID';
 
     /**
      * Configuration constructor.
@@ -74,6 +86,10 @@ class Configuration {
 
         if (isset($iniConfig->saml['allowSAMLAccountToUseLocalPassword'])) {
             $this->allowSAMLAccountToUseLocalPassword = $iniConfig->saml['allowSAMLAccountToUseLocalPassword'];
+        }
+
+        if (isset($iniConfig->saml['useOnlyNameIDAssertionToAuthenticate'])) {
+            $this->useOnlyNameIDAssertionToAuthenticate = $iniConfig->saml['useOnlyNameIDAssertionToAuthenticate'];
         }
 
         $this->fixConfigValues($iniConfig);
@@ -444,6 +460,15 @@ class Configuration {
     }
 
     /**
+     * get the nameIdPlaceholder value
+     * @return string
+     */
+    function getNameIdPlaceholder()
+    {
+        return $this->nameIdPlaceholder;
+    }
+
+    /**
      * indicates if accounts should be created after authentication if they
      * don't exist.
      * @return bool true if yes
@@ -462,6 +487,15 @@ class Configuration {
         return $this->allowSAMLAccountToUseLocalPassword;
     }
 
+    /**
+     * says if the user should be created/authenticated using only the loginAttribute property.
+     * attributesMapping (Login and E-Mail) will be both overwritten by the loginAttribute value
+     * @return bool
+     */
+    function mustUseOnlyNameIDAssertionToAuthenticate()
+    {
+        return $this->useOnlyNameIDAssertionToAuthenticate;
+    }
 
     function getIdpURL()
     {

--- a/saml/lib/ConfigurationModifier.php
+++ b/saml/lib/ConfigurationModifier.php
@@ -24,6 +24,14 @@ class ConfigurationModifier extends Configuration
     }
 
     /**
+     * @param bool $onlyNameID
+     */
+    public function setUseOnlyNameIDAssertionToAuthenticate($onlyNameID)
+    {
+        $this->useOnlyNameIDAssertionToAuthenticate = !!$onlyNameID;
+    }
+
+    /**
      * @param bool $automatic
      */
     public function setAutomaticAccountCreation($automatic)
@@ -198,6 +206,9 @@ class ConfigurationModifier extends Configuration
         $mapping['__login'] = $this->loginAttribute;
         $liveConfig->setValues($mapping, 'saml:attributes-mapping');
         $appConfig->{'saml:attributes-mapping'} = $mapping;
+
+        $liveConfig->setValue('useOnlyNameIDAssertionToAuthenticate', $this->useOnlyNameIDAssertionToAuthenticate, 'saml');
+        $appConfig->saml['useOnlyNameIDAssertionToAuthenticate'] = $this->useOnlyNameIDAssertionToAuthenticate;
 
         $liveConfig->setValue('automaticAccountCreation', $this->automaticAccountCreation, 'saml');
         $appConfig->saml['automaticAccountCreation'] = $this->automaticAccountCreation;

--- a/saml/lib/Saml.php
+++ b/saml/lib/Saml.php
@@ -101,6 +101,13 @@ class Saml
 
         $loginAttr = $this->config->getSAMLAttributeForLogin();
         $attributes = $auth->getAttributes();
+
+        if($this->config->mustUseOnlyNameIDAssertionToAuthenticate()){
+            $attributes = array();
+            $loginAttr = $this->config->getNameIdPlaceholder();
+            $attributes[$loginAttr] = array($auth->getNameId());
+        }
+
         if (empty($attributes)) {
             throw new LoginException(
                 \jLocale::get('saml~auth.authentication.error.saml.attributes.missing', array($loginAttr)),

--- a/samladmin/forms/attrmapping.form.xml
+++ b/samladmin/forms/attrmapping.form.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form xmlns="http://jelix.org/ns/forms/1.1">
 
+    <hidden ref="nameIdPlaceholder" />
+
     <input ref="login" type="string" required="true">
         <label locale="samladmin~admin.attrmapping.form.login.label"/>
     </input>
@@ -8,6 +10,11 @@
     <group ref="attrsgroup">
         <label locale="samladmin~admin.attrmapping.form.attrsgroup.label" />
     </group>
+
+    <checkbox ref="useOnlyNameIDAssertionToAuthenticate">
+        <label locale="samladmin~admin.attrmapping.form.useOnlyNameIDAssertionToAuthenticate.label"/>
+        <help locale="samladmin~admin.attrmapping.form.useOnlyNameIDAssertionToAuthenticate.help"/>
+    </checkbox>
 
     <checkbox ref="automaticAccountCreation">
         <label locale="samladmin~admin.attrmapping.form.automaticAccountCreation.label"/>

--- a/samladmin/locales/en_US/admin.UTF-8.properties
+++ b/samladmin/locales/en_US/admin.UTF-8.properties
@@ -60,6 +60,8 @@ attrmapping.title=Configuration of SAML accounts
 attrmapping.error.not.set=Configuration of SAML attributes is not completed
 attrmapping.form.login.label=SAML attribute containing the id/login of the user
 attrmapping.form.attrsgroup.label=list of SAML attributes corresponding to each user properties
+attrmapping.form.useOnlyNameIDAssertionToAuthenticate.label=Ignore attributes from SAML response and use only the NameID assertion to create or authenticate the user
+attrmapping.form.useOnlyNameIDAssertionToAuthenticate.help=Some IP (Identity provider) might not be configured to forward user's attributes. WARNING: if checked, the mandatory fields required in the attributes section used to create the local user will be filled with the NameID value.
 attrmapping.form.automaticAccountCreation.label=User accounts are automatically created if they don't exist into the application, when user use SAML to authenticate themselves
 attrmapping.form.allowSAMLAccountToUseLocalPassword.label=Users using SAML can also use their local accounts of the application to login
 

--- a/samladmin/templates/attrmapping.tpl
+++ b/samladmin/templates/attrmapping.tpl
@@ -9,6 +9,12 @@
         {ctrl_label 'attrsgroup'}
         {ctrl_control 'attrsgroup'}
     </div>
+
+    <p>
+        {ctrl_control 'useOnlyNameIDAssertionToAuthenticate'}
+        {ctrl_label 'useOnlyNameIDAssertionToAuthenticate'}
+    </p>
+
     <p>
         {ctrl_control 'automaticAccountCreation'}
         {ctrl_label 'automaticAccountCreation'}

--- a/samladmin/www/attr.js
+++ b/samladmin/www/attr.js
@@ -1,0 +1,25 @@
+$(document).ready(()=>{
+
+    document.getElementById('jforms_samladmin_attrmapping').addEventListener('jformsready', ()=>{
+        let form = jFormsJQ.getForm('jforms_samladmin_attrmapping').element;
+        let onlyNameIdCheckbox = form.elements['useOnlyNameIDAssertionToAuthenticate'];
+        let nameIdPlaceholder = form.elements['nameIdPlaceholder'].value;
+        if (onlyNameIdCheckbox) {
+            onlyNameIdCheckbox.addEventListener('change', (e)=>{
+                return useOnlyNameIDAssertionToAuthenticateChange(e.target.checked);
+            })
+
+            useOnlyNameIDAssertionToAuthenticateChange(onlyNameIdCheckbox.checked);
+        }
+
+        function useOnlyNameIDAssertionToAuthenticateChange(checked){
+            let attrRequired = document.querySelectorAll("#jforms_samladmin_attrmapping_attrsgroup input.jforms-required");
+            let nameIdFileds = [form.login, ...attrRequired];
+
+            nameIdFileds.forEach((f)=>{
+                f.value = checked ? nameIdPlaceholder : f.value;
+                f.disabled = checked ? true : false;//!f.disabled;
+            })
+        }
+    })
+})


### PR DESCRIPTION
Hi!

We encountered a situation where an IP (Identity provider) does not provide SAML `Attributes` as part of response, and unfortunately we cannot set those attributes in any way.

As far as we know, `attributes` are not a mandatory part for the SAML response protocol but, at the moment, jelix saml-module requires such attributes as mandatory for user creation/authentication on the jelix user DB.

So, given the following assumptions:

- attributes are not mandatory
- administrator user is aware of what he/she/it is doing

we would propose this PR which allow to authenticate / create the jelix user using only the `NameID`

Practical changes:

- a new checkbox is available in the attributes configuration page (default off)
![image](https://github.com/user-attachments/assets/fed69592-d895-4997-9726-030d81a6dae5)

-if checked, the `SAML attribute containing the id/login of the user` field and all mandatory attributes will be disabled and filled with an arbitrary placeholder 'NameID'
![image](https://github.com/user-attachments/assets/95505ac1-dca6-40e3-bc65-ecd82357c8df)

This interface management, although not very practical at the moment, serves to highlight to the user that the option is enabled.

As a result, when a user logs in for the first time, all required fields in the attributes section (marked as required by the jelix db provider) are filled with the `NameID` value. Obviously the value of the ǸameID could be formatted in various ways, so for example if `NameID` is of type username and email is a required field, the email field will be filled with a string that is not formatted as email.

We are well aware that this type of configuration is situational, but it could make the module more flexible partly by placing responsibility on the system administrator.

Thank you!

@u-cav
 